### PR TITLE
Fix body params for patients and practicioners in swagger documentation

### DIFF
--- a/controllers/patients.js
+++ b/controllers/patients.js
@@ -76,6 +76,20 @@ const createPatient = async (req, res, next) => {
         #swagger.description='Creates a patient'
 
         #swagger.security = [{OAuth2:["user"]}]
+
+        #swagger.parameters['body'] = { in: 'body', schema: { name: "Sophia Adams",
+          dob: "09/18/79",
+          email: "sophia.adams@example.com",
+          address: {
+            street: "567 Maple Street",
+            city: "Villageland",
+            zip: "67890",
+          },
+          phone: "555-789-2345",
+          insurer: "National",
+          request:
+            "Morbi posuere enim quis ornare laoreet. Donec imperdiet lacus odio, ut sollicitudin velit vulputate non. Sed mattis dolor purus, vel efficitur metus porta vel. Donec in aliquam nisl. Suspendisse venenatis eros molestie nunc eleifend, vel euismod elit tincidunt.",
+        }}
         
         #swagger.responses[400] = {description: 'Some error occurred while creating the patient record.'}
 
@@ -120,6 +134,20 @@ const updatePatient = async (req, res, next) => {
     #swagger.description='Updates a patient record'
 
     #swagger.security = [{OAuth2:["user"]}]
+
+    #swagger.parameters['body'] = { in: 'body', schema: { name: "Sophia Adams",
+          dob: "09/18/79",
+          email: "sophia.adams@example.com",
+          address: {
+            street: "567 Maple Street",
+            city: "Villageland",
+            zip: "67890",
+          },
+          phone: "555-789-2345",
+          insurer: "National",
+          request:
+            "Morbi posuere enim quis ornare laoreet. Donec imperdiet lacus odio, ut sollicitudin velit vulputate non. Sed mattis dolor purus, vel efficitur metus porta vel. Donec in aliquam nisl. Suspendisse venenatis eros molestie nunc eleifend, vel euismod elit tincidunt.",
+    }}
 
     #swagger.responses[400] = {description: 'Invalid record ID or no patient record found with that id.'}
 

--- a/controllers/practitioners.js
+++ b/controllers/practitioners.js
@@ -138,6 +138,19 @@ const createPractitioner = async (req, res, next) => {
         #swagger.description='Creates a practitioner'
 
         #swagger.security = [{OAuth2:["user"]}]
+
+        #swagger.parameters['body'] = { in: 'body', schema: { 
+          name: "Jessica Wilson",
+          specialization: "Cardiovascular Disease",
+          dea_number: "C91224313",
+          address: {
+            street: "467 Elm Street",
+            city: "Townsville",
+            zip: "54321",
+          },
+          phone: "555-333-701",
+          email: "jessica.wilson@medical.com", } 
+        }
         
         #swagger.responses[201] = {description: 'A new practitioner has been added to the database'}
         
@@ -182,6 +195,19 @@ const updatePractitioner = async (req, res, next) => {
     #swagger.description='Updates a practitioner record'
 
     #swagger.security = [{OAuth2:["user"]}]
+
+    #swagger.parameters['body'] = { in: 'body', schema: { 
+          name: "Jessica Wilson",
+          specialization: "Cardiovascular Disease",
+          dea_number: "C91224313",
+          address: {
+            street: "467 Elm Street",
+            city: "Townsville",
+            zip: "54321",
+          },
+          phone: "555-333-701",
+          email: "jessica.wilson@medical.com", } 
+    }
 
     #swagger.responses[400] = {description: 'Invalid record ID or no practitioner record found with that id.'}
      

--- a/swagger-output.json
+++ b/swagger-output.json
@@ -119,25 +119,45 @@
               "type": "object",
               "properties": {
                 "name": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Sophia Adams"
                 },
                 "dob": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "09/18/79"
                 },
                 "email": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "sophia.adams@example.com"
                 },
                 "address": {
-                  "example": "any"
+                  "type": "object",
+                  "properties": {
+                    "street": {
+                      "type": "string",
+                      "example": "567 Maple Street"
+                    },
+                    "city": {
+                      "type": "string",
+                      "example": "Villageland"
+                    },
+                    "zip": {
+                      "type": "string",
+                      "example": "67890"
+                    }
+                  }
                 },
                 "phone": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "555-789-2345"
                 },
                 "insurer": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "National"
                 },
                 "request": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Morbi posuere enim quis ornare laoreet. Donec imperdiet lacus odio, ut sollicitudin velit vulputate non. Sed mattis dolor purus, vel efficitur metus porta vel. Donec in aliquam nisl. Suspendisse venenatis eros molestie nunc eleifend, vel euismod elit tincidunt."
                 }
               }
             }
@@ -219,25 +239,45 @@
               "type": "object",
               "properties": {
                 "name": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Sophia Adams"
                 },
                 "dob": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "09/18/79"
                 },
                 "email": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "sophia.adams@example.com"
                 },
                 "address": {
-                  "example": "any"
+                  "type": "object",
+                  "properties": {
+                    "street": {
+                      "type": "string",
+                      "example": "567 Maple Street"
+                    },
+                    "city": {
+                      "type": "string",
+                      "example": "Villageland"
+                    },
+                    "zip": {
+                      "type": "string",
+                      "example": "67890"
+                    }
+                  }
                 },
                 "phone": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "555-789-2345"
                 },
                 "insurer": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "National"
                 },
                 "request": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Morbi posuere enim quis ornare laoreet. Donec imperdiet lacus odio, ut sollicitudin velit vulputate non. Sed mattis dolor purus, vel efficitur metus porta vel. Donec in aliquam nisl. Suspendisse venenatis eros molestie nunc eleifend, vel euismod elit tincidunt."
                 }
               }
             }
@@ -347,22 +387,41 @@
               "type": "object",
               "properties": {
                 "name": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Jessica Wilson"
                 },
                 "specialization": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Cardiovascular Disease"
                 },
                 "dea_number": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "C91224313"
                 },
                 "address": {
-                  "example": "any"
+                  "type": "object",
+                  "properties": {
+                    "street": {
+                      "type": "string",
+                      "example": "467 Elm Street"
+                    },
+                    "city": {
+                      "type": "string",
+                      "example": "Townsville"
+                    },
+                    "zip": {
+                      "type": "string",
+                      "example": "54321"
+                    }
+                  }
                 },
                 "phone": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "555-333-701"
                 },
                 "email": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "jessica.wilson@medical.com"
                 }
               }
             }
@@ -444,22 +503,41 @@
               "type": "object",
               "properties": {
                 "name": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Jessica Wilson"
                 },
                 "specialization": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Cardiovascular Disease"
                 },
                 "dea_number": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "C91224313"
                 },
                 "address": {
-                  "example": "any"
+                  "type": "object",
+                  "properties": {
+                    "street": {
+                      "type": "string",
+                      "example": "467 Elm Street"
+                    },
+                    "city": {
+                      "type": "string",
+                      "example": "Townsville"
+                    },
+                    "zip": {
+                      "type": "string",
+                      "example": "54321"
+                    }
+                  }
                 },
                 "phone": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "555-333-701"
                 },
                 "email": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "jessica.wilson@medical.com"
                 }
               }
             }


### PR DESCRIPTION
### Description

This adds missing body parameters for patients and practicioners, specifically the address sub properties

### Significant Changes

•⁠  Modify Swagger comment for practicioners
•⁠  Modify Swagger comment for patients
•⁠  ⁠Regenerate swagger-output.json

### Checklist
•⁠  ⁠[x] Brief *description* of work completed, and any technical decisions made as part of the PR
•⁠  ⁠[x] *Reviewers* have been assigned 
•⁠  ⁠[x] PR link *shared* on Teams
•⁠  ⁠[ ] 2 reviews *received*
